### PR TITLE
Change RegEx to allow numbers as part of the path

### DIFF
--- a/src/lib/renderer.js
+++ b/src/lib/renderer.js
@@ -52,7 +52,7 @@ module.exports = class Renderer {
             fs.outputFile(filePath, content, async (err) => {
                 if (err) throw err;
             });
-            const page = path.relative(this.outputDir, filePath).match(/(?<category>[A-z-]+)\/(?<pageId>[A-z-]+).md$/);
+            const page = path.relative(this.outputDir, filePath).match(/(?<category>[A-z][A-z0-9-]*)\/(?<pageId>[A-z][A-z0-9-]*).md$/);
             const slug = path.join(page.groups.category, page.groups.pageId);
             return { category: startCase(page.groups.category), slug: slug };
         }


### PR DESCRIPTION
This resolves an issue with the file `scalars/float-8.md` that leads to

```
% npx docusaurus graphql-to-doc
(node:21800) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'groups' of null
    at Renderer.renderTypeEntities (/doc/node_modules/@edno/docusaurus2-graphql-doc-generator/src/lib/renderer.js:56:41)
    at /doc/node_modules/@edno/docusaurus2-graphql-doc-generator/src/lib/renderer.js:38:68
    at Array.map (<anonymous>)
    at Renderer.renderRootTypes (/doc/node_modules/@edno/docusaurus2-graphql-doc-generator/src/lib/renderer.js:38:49)
    at /doc/node_modules/@edno/docusaurus2-graphql-doc-generator/src/lib/generator.js:28:68
    at Array.map (<anonymous>)
    at /doc/node_modules/@edno/docusaurus2-graphql-doc-generator/src/lib/generator.js:28:48
(node:21800) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:21800) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(this language is not supported, see … for more info).
```