### PR TITLE
Fix homePage typo in plugin options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module.exports = {
         schema: "https://swapi.graph.cool/",
         rootPath: "./docs", // docs will be generated under './docs/swapi' (outputDocPath/baseURL)
         baseURL: "swapi",
-        homePage: "./docs/swapi.md",
+        homepage: "./docs/swapi.md",
       },
     ],
 };


### PR DESCRIPTION
Changes the capitalization of homePage to homepage to match options.